### PR TITLE
find from activerel based on association direction

### DIFF
--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -49,7 +49,6 @@ module Neo4j
         end
 
         def target_class_names
-          puts "fuuuck"
           option = target_class_option(derive_model_class)
 
           @target_class_names ||= if option.is_a?(Array)

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -19,10 +19,10 @@ module Neo4j
 
         def derive_model_class
           return @model_class unless @model_class.nil?
-
           return nil if relationship_class.nil?
-          return false if relationship_class.to_class.to_s.to_sym == :any
-          relationship_class.to_class
+          dir_class = direction == :in ? :from_class : :to_class
+          return false if relationship_class.send(dir_class).to_s.to_sym == :any
+          relationship_class.send(dir_class)
         end
 
         def target_class_option(model_class)
@@ -49,6 +49,7 @@ module Neo4j
         end
 
         def target_class_names
+          puts "fuuuck"
           option = target_class_option(derive_model_class)
 
           @target_class_names ||= if option.is_a?(Array)

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -179,12 +179,25 @@ describe Neo4j::ActiveNode::HasN::Association do
         end
 
         context 'targeting a specific class' do
-          before(:each) do
-            stub_const 'Fizzl', Class.new { include Neo4j::ActiveNode }
-            TheRel.to_class(Fizzl)
+          context 'outbound' do
+            before(:each) do
+              stub_const 'Fizzl', Class.new { include Neo4j::ActiveNode }
+              TheRel.to_class(Fizzl)
+            end
+
+            it { should == ['::Fizzl'] }
           end
 
-          it { should == ['::Fizzl'] }
+          context 'inbound' do
+            let(:direction) { :in }
+
+            before(:each) do
+              stub_const 'Buzz', Class.new { include Neo4j::ActiveNode }
+              TheRel.from_class(Buzz)
+            end
+
+            it { should == ['::Buzz'] }
+          end
         end
       end
     end


### PR DESCRIPTION
This lets the check against the rel class work for `has_many :in`. Doing it as a PR on your branch since it's your code that I'm messing with, feel free to ignore and implement differently.
